### PR TITLE
Remove Ythisen's blizzard blue

### DIFF
--- a/sass/flair.scss
+++ b/sass/flair.scss
@@ -139,7 +139,6 @@
 @include blizzard-employee('Kaivax');
 @include blizzard-employee('aeridel');
 @include blizzard-employee('Dromogaz');
-@include blizzard-employee('CM_Ythisens');
 @include blizzard-employee('Glaxigrav');
 @include blizzard-employee('Dmachine52');
 @include blizzard-employee('BlizzardCS_Scout');


### PR DESCRIPTION
- since he's at bioware now, it really doesn't make sense for him to be
blizzard official
- somebody is probably going to have to rebuild this bad boy